### PR TITLE
Default routing

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -36,7 +36,14 @@ then
   echo '       Using existing `static.json`'
 else
   echo '       Writing `static.json` to support create-react-app'
-  echo '{ "root": "build/" }' > static.json
+  cat << EOF > static.json
+{
+  "root": "build/",
+  "routes": {
+    "/**": "index.html"
+  }
+}
+EOF
 fi
 
 echo '       Enabling runtime environment variables'


### PR DESCRIPTION
Configure the web-server to route all not-found requests to the client-side app `index.html`.

This will eliminate the need for most developers to think about routing config, such as why create-react-app-buildpack's [default routing seems broken](https://github.com/mars/create-react-app-buildpack/issues/144).