### PR TITLE
Deploy with auto build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Inner layer of Heroku Buildpack for create-react-app
 ====================================================
 
-See: [create-react-app-buildpack](https://github.com/mars/create-react-app-buildpack)
+See: [create-react-app-buildpack's architecture](https://github.com/mars/create-react-app-buildpack/blob/master/README.md#user-content-architecture-) for how this helps deploy React apps.
 
 [![Build Status](https://travis-ci.org/mars/create-react-app-inner-buildpack.svg?branch=master)](https://travis-ci.org/mars/create-react-app-inner-buildpack)
 

--- a/bin/compile
+++ b/bin/compile
@@ -55,17 +55,3 @@ cp "$BP_DIR/lib/injectable_env.rb" "$cra_dir/"
 profile_d_dir="$BUILD_DIR/.profile.d"
 mkdir -p "$profile_d_dir"
 cp "$BP_DIR/.profile.d/inject_react_app_env.sh" "$profile_d_dir/"
-
-# Support env vars during build:
-# * `REACT_APP_*`
-#   * https://github.com/facebookincubator/create-react-app/blob/v0.2.3/template/README.md#adding-custom-environment-variables
-# * `NODE_*`, especially for `NODE_PATH`
-#   * https://github.com/facebookincubator/create-react-app/pull/476
-# * `NPM_*`, especially for `NPM_TOKEN`
-#   * https://docs.npmjs.com/private-modules/ci-server-config
-# * `HEROKU_*`, especially for Dyno Metadata
-#   * https://devcenter.heroku.com/articles/dyno-metadata
-export_env_dir "$ENV_DIR" '^(REACT_APP_|NODE_|NPM_|HEROKU_)'
-
-# Build the javascript bundle
-npm run build


### PR DESCRIPTION
Delete the `npm run build` step, because the Node buildpack will be [doing this automatically](https://devcenter.heroku.com/changelog-items/1557).