### PR TITLE
Find all the files to alter in bash instead of ruby

### DIFF
--- a/.profile.d/inject_react_app_env.sh
+++ b/.profile.d/inject_react_app_env.sh
@@ -17,7 +17,10 @@ fi
 # Fail immediately on non-zero exit code.
 set -e
 
-for js_bundle_filename in $js_bundle_filenames
+# Find all the files to alter
+js_altered_files=`find $js_bundles | xargs grep -l REACT_APP_VARS_AS_JSON`
+
+for js_bundle_filename in $js_altered_files
 do
   echo "Injecting runtime env into $js_bundle_filename (from .profile.d/inject_react_app_env.sh)"
 


### PR DESCRIPTION
Related to the work started here https://github.com/mars/create-react-app-inner-buildpack/pull/21, this PR aims at reducing the boot time on big react applications (~1000 files).

For large projects, we can encounter `R10` errors because the time spent trying to inject the environment variables on runtime can exceed the default timeout of 60 seconds.

This patch is reducing the amount of files pass to the ruby runtime (which is kind of slow), by greping first all the files containing the `REACT_APP_VARS_AS_JSON` (in bash). Only the files will be passed to the `injectable_env.rb` script.

On my local machine i get the following result with the patch:
```shell
time .profile.d/inject_react_app_env.sh
.profile.d/inject_react_app_env.sh  1.87s user 0.16s system 82% cpu 2.454 total
```

And without:
```shell
time .profile.d/inject_react_app_env.sh
.profile.d/inject_react_app_env.sh  13.07s user 6.86s system 90% cpu 22.003 total
```

which can be of a huge help for big apps.
